### PR TITLE
Diagonal measurement, optional via Map Settings.

### DIFF
--- a/Tapeline/locale/en/en.cfg
+++ b/Tapeline/locale/en/en.cfg
@@ -13,6 +13,7 @@ tapeline=Tapeline
 [mod-setting-name]
 log-selection-area=Log Selection Dimensions to Chat
 draw-tilegrid-on-ground=Draw Tilegrid on Ground
+draw-diagonal=Show Diagonal Measurement
 tilegrid-line-width=Line Width
 tilegrid-clear-delay=Auto-clear Delay (seconds)
 tilegrid-background-color=Background Color
@@ -22,6 +23,7 @@ tilegrid-color-1=Grid Color
 tilegrid-color-2=Subgrid 1 Color
 tilegrid-color-3=Subgrid 2 Color
 tilegrid-color-4=Subgrid 3 Color
+tilegrid-diagonal-color=Diagonal Line Color
 
 [mod-setting-description]
 tilegrid-group-divisor=How often a subgrid is created when using a standard tapeline.

--- a/Tapeline/scripts/rendering.lua
+++ b/Tapeline/scripts/rendering.lua
@@ -84,24 +84,24 @@ function build_render_objects(data)
 
   --diagonal line and label
   if map_settings.draw_diagonal and data.area.height > 1 and data.area.width > 1 then
-			objects.diagonal_line = rendering.draw_line {
-				color = map_settings.tilegrid_diagonal_color,
-				width = map_settings.tilegrid_line_width,
-				from = {data.area.left_top.x, data.area.left_top.y},
-				to = {data.area.right_bottom.x, data.area.right_bottom.y},
-				surface = surfaceIndex,
-				draw_on_ground = map_settings.draw_tilegrid_on_ground
-      }
+    objects.diagonal_line = rendering.draw_line {
+      color = map_settings.tilegrid_diagonal_color,
+      width = map_settings.tilegrid_line_width,
+      from = {data.area.left_top.x, data.area.left_top.y},
+      to = {data.area.right_bottom.x, data.area.right_bottom.y},
+      surface = surfaceIndex,
+      draw_on_ground = map_settings.draw_tilegrid_on_ground
+    }
 
-      objects.labels.diagonal = rendering.draw_text {
-        text = data.diagonal_text,
-        surface = surfaceIndex,
-        target = {data.area.midpoints.x, data.area.midpoints.y},
-        color = map_settings.tilegrid_label_color,
-        alignment = 'center',
-        scale = 2
-      }
-	end
+   objects.labels.diagonal = rendering.draw_text {
+     text = data.diagonal_text,
+     surface = surfaceIndex,
+     target = {data.area.midpoints.x, data.area.midpoints.y},
+     color = map_settings.tilegrid_label_color,
+     alignment = 'center',
+     scale = 2
+    }
+  end
 
     return objects
 

--- a/Tapeline/scripts/rendering.lua
+++ b/Tapeline/scripts/rendering.lua
@@ -82,6 +82,27 @@ function build_render_objects(data)
         }
 	end
 
+  --diagonal line and label
+  if map_settings.draw_diagonal and data.area.height > 1 and data.area.width > 1 then
+			objects.diagonal_line = rendering.draw_line {
+				color = map_settings.tilegrid_diagonal_color,
+				width = map_settings.tilegrid_line_width,
+				from = {data.area.left_top.x, data.area.left_top.y},
+				to = {data.area.right_bottom.x, data.area.right_bottom.y},
+				surface = surfaceIndex,
+				draw_on_ground = map_settings.draw_tilegrid_on_ground
+      }
+
+      objects.labels.diagonal = rendering.draw_text {
+        text = data.diagonal_text,
+        surface = surfaceIndex,
+        target = {data.area.midpoints.x, data.area.midpoints.y},
+        color = map_settings.tilegrid_label_color,
+        alignment = 'center',
+        scale = 2
+      }
+	end
+
     return objects
 
 end

--- a/Tapeline/scripts/tilegrid.lua
+++ b/Tapeline/scripts/tilegrid.lua
@@ -31,6 +31,8 @@ function get_global_settings()
 
 	data.draw_tilegrid_on_ground = settings['draw-tilegrid-on-ground'].value
 	
+  data.draw_diagonal = settings['draw-diagonal'].value
+
 	data.tilegrid_background_color = stdlib.color.set(defines.color[settings['tilegrid-background-color'].value], 0.6)
 	data.tilegrid_border_color = stdlib.color.set(defines.color[settings['tilegrid-border-color'].value])
 	data.tilegrid_label_color = stdlib.color.set(defines.color[settings['tilegrid-label-color'].value], 0.8)
@@ -38,6 +40,7 @@ function get_global_settings()
 	data.tilegrid_div_color_2 = stdlib.color.set(defines.color[settings['tilegrid-color-2'].value])
 	data.tilegrid_div_color_3 = stdlib.color.set(defines.color[settings['tilegrid-color-3'].value])
 	data.tilegrid_div_color_4 = stdlib.color.set(defines.color[settings['tilegrid-color-4'].value])
+	data.tilegrid_diagonal_color = stdlib.color.set(defines.color[settings['tilegrid-diagonal-color'].value])
 
 	return data
 
@@ -57,7 +60,8 @@ function on_tick()
             if not stdlib.position.equals(from_pos(t.last_capsule_pos), from_pos(data.origin)) then
                 if data.settings.grid_autoclear then global.perish[t.cur_tilegrid_index] = game.ticks_played + data.time_to_live
                 else create_settings_button(global[t.cur_tilegrid_index]) end
-                if data.settings.log_selection_area then data.player.print('Dimensions: ' .. data.area.width .. 'x' .. data.area.height) end
+                if data.settings.log_selection_area then data.player.print('Dimensions: ' .. data.area.width .. 'x' .. data.area.height ..
+                                                                            (data.diagonal_text and ' Diagonal: ' .. data.diagonal_text or '')) end
             else
                 destroy_tilegrid_data(t.cur_tilegrid_index)
             end
@@ -159,6 +163,11 @@ function update_tilegrid_data(e)
     data.area = stdlib.area.construct(left_top.x, left_top.y, right_bottom.x, right_bottom.y):normalize():ceil():corners()
     data.area.size,data.area.width,data.area.height = data.area:size()
     data.area.midpoints = stdlib.area.center(data.area)
+    -- diagonal measurement
+    if global.map_settings.draw_diagonal then
+      data.diagonal = math.sqrt ( (data.area.width * data.area.width) + (data.area.height * data.area.height) )
+      data.diagonal_text = string.format("%.2f", data.diagonal) -- round to two decimal places.
+    end
     -- update anchors
     if e.position.x < data.origin.x then
         if e.position.y < data.origin.y then

--- a/Tapeline/settings.lua
+++ b/Tapeline/settings.lua
@@ -38,6 +38,13 @@ data:extend({
         order = 'b'
     },
     {
+        type = 'bool-setting',
+        name = 'draw-diagonal',
+        setting_type = 'runtime-global',
+        default_value = false,
+        order = 'ba'
+    },
+    {
         type = 'double-setting',
         name = 'tilegrid-line-width',
         setting_type = 'runtime-global',
@@ -106,5 +113,13 @@ data:extend({
         default_value = 'yellow',
         allowed_values = possible_colors,
         order = 'k'
+    },
+    {
+        type = 'string-setting',
+        name = 'tilegrid-diagonal-color',
+        setting_type = 'runtime-global',
+        default_value = 'white',
+        allowed_values = possible_colors,
+        order = 'l'
     }
 })


### PR DESCRIPTION
Hi Raiguard

This pull request is an implementation of optional diagonal measurement.  When enabled via Map Settings, a diagonal line is drawn from top left to bottom right, which shows the diagonal distance between those two points.

I find this very useful when working on bot throughput tests, where it is helpful to know the point-to-point distance between two places.

More details are included in a feature request discussion thread on your mod portal here: https://mods.factorio.com/mod/Tapeline/discussion/5d22154c490b66000d7ace80

Thanks very much

Tom (TheBloke)