### PR TITLE
Fix game freezing when having a divisor size of 0

### DIFF
--- a/scripts/tape.lua
+++ b/scripts/tape.lua
@@ -214,11 +214,12 @@ local function update_tape(self)
   end
 
   draw_lines(self.player.mod_settings["tl-tape-line-color-1"].value --[[@as Color]], 1)
-
   if self.settings.mode == "subgrid" then
-    draw_lines(self.player.mod_settings["tl-tape-line-color-2"].value --[[@as Color]], self.settings.subgrid_size)
-    draw_lines(self.player.mod_settings["tl-tape-line-color-3"].value --[[@as Color]], self.settings.subgrid_size ^ 2)
-    draw_lines(self.player.mod_settings["tl-tape-line-color-4"].value --[[@as Color]], self.settings.subgrid_size ^ 3)
+    if self.settings.subgrid_size > 1 then
+      draw_lines(self.player.mod_settings["tl-tape-line-color-2"].value --[[@as Color]], self.settings.subgrid_size)
+      draw_lines(self.player.mod_settings["tl-tape-line-color-3"].value --[[@as Color]], self.settings.subgrid_size ^ 2)
+      draw_lines(self.player.mod_settings["tl-tape-line-color-4"].value --[[@as Color]], self.settings.subgrid_size ^ 3)
+    end
   else
     draw_lines(
       self.player.mod_settings["tl-tape-line-color-2"].value --[[@as Color]],

--- a/scripts/tape.lua
+++ b/scripts/tape.lua
@@ -214,6 +214,7 @@ local function update_tape(self)
   end
 
   draw_lines(self.player.mod_settings["tl-tape-line-color-1"].value --[[@as Color]], 1)
+  
   if self.settings.mode == "subgrid" then
     if self.settings.subgrid_size > 1 then
       draw_lines(self.player.mod_settings["tl-tape-line-color-2"].value --[[@as Color]], self.settings.subgrid_size)

--- a/scripts/tape.lua
+++ b/scripts/tape.lua
@@ -214,7 +214,7 @@ local function update_tape(self)
   end
 
   draw_lines(self.player.mod_settings["tl-tape-line-color-1"].value --[[@as Color]], 1)
-  
+
   if self.settings.mode == "subgrid" then
     if self.settings.subgrid_size > 1 then
       draw_lines(self.player.mod_settings["tl-tape-line-color-2"].value --[[@as Color]], self.settings.subgrid_size)

--- a/scripts/tape.lua
+++ b/scripts/tape.lua
@@ -475,7 +475,7 @@ local function on_change_divisor(e)
     return
   end
   if settings.mode == "subgrid" then
-    settings.subgrid_size = math.max(0, settings.subgrid_size + delta)
+    settings.subgrid_size = math.max(1, settings.subgrid_size + delta)
   else
     settings.splits = math.max(2, settings.splits + delta)
   end


### PR DESCRIPTION
When subgrid_size is 0 it causes an infinite loop when trying to use the tapeline.
Fixes #45
The minimum subgrid_size is now 1.
When the subgrid_size is 1 then don't draw the subgrid.
Left with subgrid and right without subgrid.
![image](https://github.com/user-attachments/assets/59879bab-7824-42a9-a79a-644273e098ab)
